### PR TITLE
import emmo v1.0.0-beta7

### DIFF
--- a/catalog-v001.xml
+++ b/catalog-v001.xml
@@ -1,7 +1,54 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
-    <uri id="Imports Wizard Entry" name="http://emmo.info/emmo/1.0.0-beta5" uri="https://raw.githubusercontent.com/emmo-repo/EMMO/1.0.0-beta5/emmo.ttl"/>
+    <uri id="Imports Wizard Entry" name="https://w3id.org/emmo/1.0.0-beta7" uri="https://raw.githubusercontent.com/emmo-repo/EMMO/1.0.0-beta7/emmo.ttl"/>
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=false, version=2" prefer="public" xml:base="">
-        <uri name="https://w3id.org/emmo/domain/chemicalsubstance/0.3.0-beta/chemicalsubstance" uri="./chemicalsubstance.ttl"/>
+        <uri name="https://w3id.org/emmo/domain/chemicalsubstance/0.4.0-beta/chemicalsubstance" uri="./chemicalsubstance.ttl"/>
+
+        <uri name="https://w3id.org/emmo/1.0.0-beta7/mereocausality"                  uri="https://raw.githubusercontent.com/emmo-repo/EMMO/1.0.0-beta7/mereocausality/mereocausality.ttl"/>
+
+        <uri name="https://w3id.org/emmo/1.0.0-beta7/perspectives"                    uri="https://raw.githubusercontent.com/emmo-repo/EMMO/1.0.0-beta7/perspectives/perspectives.ttl"/>
+        <uri name="https://w3id.org/emmo/1.0.0-beta7/perspectives/perspective"        uri="https://raw.githubusercontent.com/emmo-repo/EMMO/1.0.0-beta7/perspectives/perspective.ttl"/>
+        <uri name="https://w3id.org/emmo/1.0.0-beta7/perspectives/semiotics"          uri="https://raw.githubusercontent.com/emmo-repo/EMMO/1.0.0-beta7/perspectives/semiotics.ttl"/>
+        <uri name="https://w3id.org/emmo/1.0.0-beta7/perspectives/perceptual"         uri="https://raw.githubusercontent.com/emmo-repo/EMMO/1.0.0-beta7/perspectives/perceptual.ttl"/>
+        <uri name="https://w3id.org/emmo/1.0.0-beta7/perspectives/reductionistic"     uri="https://raw.githubusercontent.com/emmo-repo/EMMO/1.0.0-beta7/perspectives/reductionistic.ttl"/>
+        <uri name="https://w3id.org/emmo/1.0.0-beta7/perspectives/holistic"           uri="https://raw.githubusercontent.com/emmo-repo/EMMO/1.0.0-beta7/perspectives/holistic.ttl"/>
+        <uri name="https://w3id.org/emmo/1.0.0-beta7/perspectives/persistence"        uri="https://raw.githubusercontent.com/emmo-repo/EMMO/1.0.0-beta7/perspectives/persistence.ttl"/>
+        <uri name="https://w3id.org/emmo/1.0.0-beta7/perspectives/physicalistic"      uri="https://raw.githubusercontent.com/emmo-repo/EMMO/1.0.0-beta7/perspectives/physicalistic.ttl"/>
+        <uri name="https://w3id.org/emmo/1.0.0-beta7/perspectives/standardmodel"      uri="https://raw.githubusercontent.com/emmo-repo/EMMO/1.0.0-beta7/perspectives/standardmodel.ttl"/>
+        <uri name="https://w3id.org/emmo/1.0.0-beta7/perspectives/data"               uri="https://raw.githubusercontent.com/emmo-repo/EMMO/1.0.0-beta7/perspectives/data.ttl"/>
+
+        <uri name="https://w3id.org/emmo/1.0.0-beta7/multiperspective"                uri="https://raw.githubusercontent.com/emmo-repo/EMMO/1.0.0-beta7/multiperspective/multiperspective.ttl"/>
+        <uri name="https://w3id.org/emmo/1.0.0-beta7/multiperspective/persholistic"   uri="https://raw.githubusercontent.com/emmo-repo/EMMO/1.0.0-beta7/multiperspective/persholistic.ttl"/>
+        <uri name="https://w3id.org/emmo/1.0.0-beta7/multiperspective/properties"     uri="https://raw.githubusercontent.com/emmo-repo/EMMO/1.0.0-beta7/multiperspective/properties.ttl"/>
+        <uri name="https://w3id.org/emmo/1.0.0-beta7/multiperspective/symbolic"       uri="https://raw.githubusercontent.com/emmo-repo/EMMO/1.0.0-beta7/multiperspective/symbolic.ttl"/>
+        <uri name="https://w3id.org/emmo/1.0.0-beta7/multiperspective/information"    uri="https://raw.githubusercontent.com/emmo-repo/EMMO/1.0.0-beta7/multiperspective/information.ttl"/>
+        <uri name="https://w3id.org/emmo/1.0.0-beta7/multiperspective/workflow"       uri="https://raw.githubusercontent.com/emmo-repo/EMMO/1.0.0-beta7/multiperspective/workflow.ttl"/>
+
+        <uri name="https://w3id.org/emmo/1.0.0-beta7/disciplines"                     uri="https://raw.githubusercontent.com/emmo-repo/EMMO/1.0.0-beta7/disciplines/disciplines.ttl"/>
+        <uri name="https://w3id.org/emmo/1.0.0-beta7/disciplines/chemistry"           uri="https://raw.githubusercontent.com/emmo-repo/EMMO/1.0.0-beta7/disciplines/chemistry.ttl"/>
+        <uri name="https://w3id.org/emmo/1.0.0-beta7/disciplines/computerscience"     uri="https://raw.githubusercontent.com/emmo-repo/EMMO/1.0.0-beta7/disciplines/computerscience.ttl"/>
+        <uri name="https://w3id.org/emmo/1.0.0-beta7/disciplines/manufacturing"       uri="https://raw.githubusercontent.com/emmo-repo/EMMO/1.0.0-beta7/disciplines/manufacturing.ttl"/>
+        <uri name="https://w3id.org/emmo/1.0.0-beta7/disciplines/materials"           uri="https://raw.githubusercontent.com/emmo-repo/EMMO/1.0.0-beta7/disciplines/materials.ttl"/>
+        <uri name="https://w3id.org/emmo/1.0.0-beta7/disciplines/math"                uri="https://raw.githubusercontent.com/emmo-repo/EMMO/1.0.0-beta7/disciplines/math.ttl"/>
+        <uri name="https://w3id.org/emmo/1.0.0-beta7/disciplines/models"              uri="https://raw.githubusercontent.com/emmo-repo/EMMO/1.0.0-beta7/disciplines/models.ttl"/>
+        <uri name="https://w3id.org/emmo/1.0.0-beta7/disciplines/periodictable"       uri="https://raw.githubusercontent.com/emmo-repo/EMMO/1.0.0-beta7/disciplines/periodictable.ttl"/>
+
+        <uri name="https://w3id.org/emmo/1.0.0-beta7/disciplines/metrology"           uri="https://raw.githubusercontent.com/emmo-repo/EMMO/1.0.0-beta7/disciplines/metrology.ttl"/>
+        <uri name="https://w3id.org/emmo/1.0.0-beta7/disciplines/isq"                 uri="https://raw.githubusercontent.com/emmo-repo/EMMO/1.0.0-beta7/disciplines/isq.ttl"/>
+        <uri name="https://w3id.org/emmo/1.0.0-beta7/disciplines/sisystem"            uri="https://raw.githubusercontent.com/emmo-repo/EMMO/1.0.0-beta7/disciplines/sisystem.ttl"/>
+
+        <uri name="https://w3id.org/emmo/1.0.0-beta7/disciplines/units"                     uri="https://raw.githubusercontent.com/emmo-repo/EMMO/1.0.0-beta7/disciplines/units/units.ttl"/>
+        <uri name="https://w3id.org/emmo/1.0.0-beta7/disciplines/units/sidimensionalunits"  uri="https://raw.githubusercontent.com/emmo-repo/EMMO/1.0.0-beta7/disciplines/units/sidimensionalunits.ttl"/>
+        <uri name="https://w3id.org/emmo/1.0.0-beta7/disciplines/units/siunits"             uri="https://raw.githubusercontent.com/emmo-repo/EMMO/1.0.0-beta7/disciplines/units/siunits.ttl"/>
+        <uri name="https://w3id.org/emmo/1.0.0-beta7/disciplines/units/coherentsiunits"     uri="https://raw.githubusercontent.com/emmo-repo/EMMO/1.0.0-beta7/disciplines/units/coherentsiunits.ttl"/>
+        <uri name="https://w3id.org/emmo/1.0.0-beta7/disciplines/units/noncoherentsiunits"  uri="https://raw.githubusercontent.com/emmo-repo/EMMO/1.0.0-beta7/disciplines/units/noncoherentsiunits.ttl"/>
+        <uri name="https://w3id.org/emmo/1.0.0-beta7/disciplines/units/prefixedsiunits"     uri="https://raw.githubusercontent.com/emmo-repo/EMMO/1.0.0-beta7/disciplines/units/prefixedsiunits.ttl"/>
+        <uri name="https://w3id.org/emmo/1.0.0-beta7/disciplines/units/siacceptedunits"     uri="https://raw.githubusercontent.com/emmo-repo/EMMO/1.0.0-beta7/disciplines/units/siacceptedunits.ttl"/>
+        <uri name="https://w3id.org/emmo/1.0.0-beta7/disciplines/units/unclassifiedunits"   uri="https://raw.githubusercontent.com/emmo-repo/EMMO/1.0.0-beta7/disciplines/units/unclassifiedunits.ttl"/>
+
+        <!-- to be removed -->
+        <uri name="https://w3id.org/emmo/1.0.0-beta7/disciplines/unitsextension"      uri="https://raw.githubusercontent.com/emmo-repo/EMMO/1.0.0-beta7/disciplines/units/unitsextension.ttl"/>
+        <uri name="https://w3id.org/emmo/1.0.0-beta7/disciplines/prefixedunits"       uri="https://raw.githubusercontent.com/emmo-repo/EMMO/1.0.0-beta7/disciplines/units/prefixedunits.ttl"/>
+        <uri name="https://w3id.org/emmo/1.0.0-beta7/disciplines/deprecated"          uri="https://raw.githubusercontent.com/emmo-repo/EMMO/1.0.0-beta7/disciplines/units/deprecated.ttl"/>
     </group>
 </catalog>

--- a/chemicalsubstance.ttl
+++ b/chemicalsubstance.ttl
@@ -3,45 +3,45 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix emmo: <http://emmo.info/emmo#> .
+@prefix emmo: <https://w3id.org/emmo#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
-@prefix annotations: <http://emmo.info/emmo/top/annotations#> .
+@prefix annotations: <https://w3id.org/emmo/top/annotations#> .
 @base <https://w3id.org/emmo/domain/chemicalsubstance/chemicalsubstance> .
 
 <https://w3id.org/emmo/domain/chemicalsubstance/chemicalsubstance> rdf:type owl:Ontology ;
 
-                                                                    owl:versionIRI <https://w3id.org/emmo/domain/chemicalsubstance/0.3.0-beta/chemicalsubstance> ;
-                                                                    owl:imports <http://emmo.info/emmo/1.0.0-beta5> ;
+                                                                    owl:versionIRI <https://w3id.org/emmo/domain/chemicalsubstance/0.4.0-beta/chemicalsubstance> ;
+                                                                    owl:imports <https://w3id.org/emmo/1.0.0-beta7> ;
                                                                     dcterms:abstract "This ontology provides terms for chemical substances that can be referenced and re-used other resources."@en ;
                                                                     dcterms:contributor "Jesper Friis" ;
                                                                     dcterms:creator "Simon Clark" ;
-                                                                    owl:versionInfo "0.3.0-beta" .
+                                                                    owl:versionInfo "0.4.0-beta" .
 
 #################################################################
 #    Annotation properties
 #################################################################
 
-###  http://emmo.info/emmo#EMMO_371f5265_fa29_4081_b722_2c530b1fdddb
+###  https://w3id.org/emmo#EMMO_371f5265_fa29_4081_b722_2c530b1fdddb
 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb rdf:type owl:AnnotationProperty ;
                                                emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Pubchem URI for a compound or substance ID."@en ;
                                                skos:prefLabel "pubChemReference"@en ;
                                                rdfs:subPropertyOf rdfs:seeAlso .
 
 
-###  http://emmo.info/emmo#EMMO_b292d30e_4d60_43f5_9f3e_9c4e00e17a10
+###  https://w3id.org/emmo#EMMO_b292d30e_4d60_43f5_9f3e_9c4e00e17a10
 emmo:EMMO_b292d30e_4d60_43f5_9f3e_9c4e00e17a10 rdf:type owl:AnnotationProperty .
 
 
-###  http://emmo.info/emmo#EMMO_b8c10b72_7cc1_4e82_b4ab_728faf504919
+###  https://w3id.org/emmo#EMMO_b8c10b72_7cc1_4e82_b4ab_728faf504919
 emmo:EMMO_b8c10b72_7cc1_4e82_b4ab_728faf504919 rdf:type owl:AnnotationProperty ;
                                                emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Corresponds to the molecular formula of the compound."@en ;
                                                skos:prefLabel "molecularFormula"@en ;
                                                rdfs:subPropertyOf rdfs:seeAlso .
 
 
-###  http://emmo.info/emmo#EMMO_f652e7d2_0b33_4d10_8d0f_2f70089982ba
+###  https://w3id.org/emmo#EMMO_f652e7d2_0b33_4d10_8d0f_2f70089982ba
 emmo:EMMO_f652e7d2_0b33_4d10_8d0f_2f70089982ba rdf:type owl:AnnotationProperty ;
                                                emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Corresponds to the IUPAC name of the compound."@en ;
                                                skos:prefLabel "IUPACName"@en ;


### PR DESCRIPTION
update the import of emmo to v1.0.0-beta7, which includes the w3id.org namespace throughout